### PR TITLE
fix: increase the jwt expiry from 5 minutes to 20 minutes.

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -16,6 +16,8 @@ const fetch = require('node-fetch')
 const jwt = require('jsonwebtoken')
 const FormData = require('form-data')
 
+const JWT_EXPIRY_SECONDS = 1200 // 20 minutes
+
 async function getOauthToken (actionURL) {
   const postOptions = {
     method: 'POST'
@@ -68,7 +70,7 @@ async function getSignedJwt (options) {
   }
 
   const jwtPayload = {
-    exp: Math.round(300 + Date.now() / 1000),
+    exp: Math.round(JWT_EXPIRY_SECONDS + Date.now() / 1000),
     iss: orgId,
     sub: technicalAccountId,
     aud: `${ims}/c/${clientId}`


### PR DESCRIPTION
Fixes #48

After investigation, it appears that the aio-lib-ims e2e test receives an expired jwt when its turn comes around (right around the 5 minute mark), and using this expired jwt fails a test that cascades into failures for the other related tests.

Increase the jwt expiry so this does not occur.

## Motivation and Context

To fix the daily `aio-lib-ims` e2e failure.

## How Has This Been Tested?

We will know if this fixed when the daily e2e test is run, and when the PR test is run.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
