### PR TITLE
fix: CI issues

### DIFF
--- a/.github/workflows/app-smoke-test.yml
+++ b/.github/workflows/app-smoke-test.yml
@@ -16,6 +16,9 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node }}
     - name: Setup CLI
       uses: actions/checkout@master
       with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [14]
+        node: [16]
         os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - run: npm i --package-lock --package-lock-only
     - run: npm ci
     - name: run e2e tests


### PR DESCRIPTION
## Description

Fixes #70

The Github Action workflows were not using the right node versions as specified in the build matrix.
Since the node versions in the build matrix were not specified or there was a typo, it defaulted to the latest node in the [Ubuntu image](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230227.2), which is node 18.14 (new these past weeks)

node-18.14 uses npm@9 which causes an issue with the smoke tests: https://github.com/adobe/asset-compute-integration-tests/issues/39

## How Has This Been Tested?

We'll see during the daily runs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
