### PR TITLE
fix: standardize ci 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x]
+        node: [14.x]
         os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - run: npm i --package-lock --package-lock-only
     - run: npm ci
     - name: run e2e tests
@@ -50,5 +50,5 @@ jobs:
       if: success()
       run: curl -s https://codecov.io/bash | bash
       env:
-        CODECOV_NAME: ${{ runner.os }} node.js ${{ matrix.node-version }}
+        CODECOV_NAME: ${{ runner.os }} node.js ${{ matrix.node }}
       shell: bash

--- a/.github/workflows/run-once.yml
+++ b/.github/workflows/run-once.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - run: npm i --package-lock --package-lock-only
     - run: npm ci
     - name: run e2e tests


### PR DESCRIPTION
Change to make the PR workflow files all use `matrix.node` to determine Node.js version

(Note: run-once was always using node 18 because it was accessing matrix.node-version to set the version, which didn't exist...)

## Related Issue

Using different names for this variable technically caused https://github.com/adobe/aio-e2e-tests/issues/70

## How Has This Been Tested?

This would be the test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
