### PR TITLE
fix: always log daily job status

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,6 +43,7 @@ jobs:
         CUSTOMER_PROFILE_API_TENANT_ID: ${{secrets.CUSTOMER_PROFILE_API_TENANT_ID}}
       run: npm run all
     - name: Log to file
+      if: ${{ always() }}
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com


### PR DESCRIPTION
Always log the daily workflow status to [logs/run.md](https://github.com/adobe/aio-e2e-tests/blob/master/logs/run.md)

## Related Issue

Closes https://github.com/adobe/aio-e2e-tests/issues/56

## How Has This Been Tested?

We won't really know until daily fails... Should we make it fail to test?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
