### PR TITLE
fix: ACNA-2369 - remove pre-release update of downloaded app plugin

### DIFF
--- a/.github/workflows/app-smoke-test.yml
+++ b/.github/workflows/app-smoke-test.yml
@@ -23,13 +23,6 @@ jobs:
       uses: actions/checkout@master
       with:
           repository: adobe/aio-cli-plugin-app
-    - name: Update package.json with an npm pre-release version
-      id: pre-release-version
-      uses: adobe/update-prerelease-npm-version@v1.0.2
-      with:
-        pre-release-tag: 'pre'
-        dependencies-to-update: '@adobe/aio-cli-lib-app-config,@adobe/aio-cli-lib-console,@adobe/aio-lib-core-config,@adobe/aio-lib-core-logging,@adobe/aio-lib-core-networking,@adobe/aio-lib-env,@adobe/aio-lib-ims,@adobe/aio-lib-runtime,@adobe/aio-lib-web,@adobe/generator-aio-app'
-        dependencies-to-update-version-tag: 'next'
     - name: Update package.json oclif.plugins
       uses: jossef/action-set-json-field@v2.1
       with:


### PR DESCRIPTION
## Motivation and Context

The smoke tests should only test the master branch of the app plugin, not any pre-release code.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
