### PR TITLE
fix: pin node to 16.7 for daily e2e

### DIFF
--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [16]
+        node: [16.7]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [16.7]
+        node: [16.7.0]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
## Description

The aio-lib-customer-profile e2e tests are timing out. In my testing this is because between Node 16.8 and Node 18, swagger-client [uses a library called undici](https://github.com/swagger-api/swagger-js#nodejs) for sending requests, which is causing timeout issues. This PR pins Node to 16.7, to avoid these issues 

## Related Issue

## Motivation and Context

## How Has This Been Tested?

Locally ran `npm run e2e` in the aio-lib-customer-profile repo

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
