### PR TITLE
fix: asset compute integration test workflow not detecting a successful run

### DIFF
--- a/.github/workflows/asset-compute-smoke-test.yml
+++ b/.github/workflows/asset-compute-smoke-test.yml
@@ -30,15 +30,13 @@ jobs:
         ./node_modules/mocha/bin/mocha test/index.test.js > consoleoutput.txt
 
         grep "App initialization finished!" consoleoutput.txt
-        grep "Successful deployment" consoleoutput.txt
-        grep "Running tests in test/asset-compute/worker" consoleoutput.txt
+        grep -e "Running tests in .*/test/asset-compute/worker" consoleoutput.txt
         grep "All tests were successful." consoleoutput.txt
 
     - id: output
       name: Write the output to console for debugging
       if: ${{ failure() }}
       run: |
-        if [ -d "ffapp" ]; then cd ffapp; fi
         cat consoleoutput.txt
 
     - id: slacknotification


### PR DESCRIPTION
## Changes

- `Successful deployment` grep check removed, there are no deploys in this test - not sure how it passed before
- `Running tests in test/asset-compute/worker` grep check modified to use a wildcard for the start of the path - the output contains the full path now
- Removed unused `ffapp` folder check (remnant for when it was part of another workflow)

## How Has This Been Tested?

- this is the test when it runs daily or on demand
- tested locally on https://github.com/adobe/asset-compute-integration-tests
- 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
