### PR TITLE
fix: disable aio-lib-events and aio-lib-web e2e tests due to upstream failures

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -42,14 +42,18 @@
     "requiredEnv": [ "EVENTS_ORG_ID", "EVENTS_API_KEY", "EVENTS_JWT_TOKEN", "EVENTS_CONSUMER_ORG_ID", "EVENTS_WORKSPACE_ID", "EVENTS_PROJECT_ID", "EVENTS_INTEGRATION_ID"],
     "requiredAuth": "oauth_s2s",
     "mapEnv": { "IMS_CLIENT_ID": "EVENTS_API_KEY" , "IMS_TOKEN": "EVENTS_JWT_TOKEN" },
-    "doNotLog": [ "EVENTS_JWT_TOKEN" ]
+    "doNotLog": [ "EVENTS_JWT_TOKEN" ],
+    "disabled": true,
+    "disabledReason": "publishEvent returns 400 from eventsingress.adobe.io - upstream SDK needs CloudEvents spec update"
   },
 
   "aio-lib-web" : {
     "repository": "https://github.com/adobe/aio-lib-web",
     "branch": "master",
     "requiredEnv": [ "RUNTIME_NAMESPACE", "RUNTIME_AUTH"],
-    "doNotLog": [ "RUNTIME_AUTH" ]
+    "doNotLog": [ "RUNTIME_AUTH" ],
+    "disabled": true,
+    "disabledReason": "undeploy e2e expects 404 but CDN now returns 200 - upstream test needs update"
   },
 
   "aio-lib-ims" : {


### PR DESCRIPTION
Temporarily disables aio-lib-events and aio-lib-web in repositories.json to unblock the daily e2e run, which has been failing continuously since long time.

## Description

The daily app-test.yml workflow has been red for ~12 months. Analysis of the [latest CI logs](https://github.com/adobe/aio-e2e-tests/actions/runs/24374988004) (run #1191, April 14 2026) shows that only 2 of 10 repos are actually failing — the other 8 either pass or are already disabled. Because runAll() is all-or-nothing, these two failures mask the health of every other library.

Temporarily disabling aio-lib-events, aio-lib-web repos e2e tests until they are fixed in respective upstream repos.

## Related Issue

https://jira.corp.adobe.com/browse/ACNA-4510


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
