### PR TITLE
fix: serialize e2e workflow runs and harden repo orchestration

### DIFF
--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      max-parallel: 1
+      fail-fast: false
       matrix:
         node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest]

--- a/src/run.js
+++ b/src/run.js
@@ -53,13 +53,16 @@ function runOne (name, params) {
   console.log(chalk.dim(`    - cloning repo ${chalk.bold(repository)}..`))
   execa.sync('git', ['clone', repository, name], { stderr: 'inherit' })
   process.chdir(name)
-  console.log(chalk.dim(`    - checking out branch ${chalk.bold(branch)}..`))
-  execa.sync('git', ['checkout', branch], { stderr: 'inherit' })
-  console.log(chalk.dim('    - installing npm packages..'))
-  execa.sync('npm', ['install'], { stderr: 'inherit' })
-  console.log(chalk.bold('    - running tests..'))
-  execa.sync('npm', ['run', 'e2e'], { stderr: 'inherit' })
-  process.chdir('..')
+  try {
+    console.log(chalk.dim(`    - checking out branch ${chalk.bold(branch)}..`))
+    execa.sync('git', ['checkout', branch], { stderr: 'inherit' })
+    console.log(chalk.dim('    - installing npm packages..'))
+    execa.sync('npm', ['install'], { stderr: 'inherit' })
+    console.log(chalk.bold('    - running tests..'))
+    execa.sync('npm', ['run', 'e2e'], { stderr: 'inherit' })
+  } finally {
+    process.chdir('..')
+  }
   console.log(chalk.green(`    - done for ${chalk.bold(name)}`))
 }
 


### PR DESCRIPTION
This PR addresses the remaining failures in the `app-test.yml` workflow after disabling `aio-lib-events` and `aio-lib-web`.

<!--- Provide a general summary of your changes in the Title above -->

## Root Cause
The workflow was running the Node matrix (`20.x`, `22.x`, `24.x`) in parallel against the same Adobe credentials and the same Runtime namespace.
That caused two classes of failures:
- `aio-lib-analytics` intermittently failed with `429 Too Many Requests`
- `aio-lib-runtime` intermittently failed because parallel jobs deployed and undeployed the same actions in the same namespace
There was also a bug in the orchestrator: if one upstream repo failed inside `runOne()`, the process never changed back to the parent directory, so later repos could be cloned inside the failed repo's directory tree.

## What This PR Changes
- adds `max-parallel: 1` to the workflow matrix so Node versions run sequentially
- adds `fail-fast: false` so all matrix jobs complete and report their individual status
- wraps `process.chdir(name)` in `runOne()` with a `try/finally` so the orchestrator always returns to the parent directory even when a repo's e2e test fails


## Related Issue

https://jira.corp.adobe.com/browse/ACNA-4510

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- `npx jest --verbose`
- 19/19 tests passing
- 100% coverage## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
