### PR TITLE
test: add dependabot coverage upload workflow pointing at dependabot-codecov-fix branch

### DIFF
--- a/.github/workflows/dependabot-coverage-upload.yml
+++ b/.github/workflows/dependabot-coverage-upload.yml
@@ -1,0 +1,33 @@
+name: Dependabot Coverage Upload
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    if: github.event.issue.pull_request != null && github.event.comment.body == '/upload-coverage'
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.gate.outputs.allowed }}
+    steps:
+      - name: Gate check
+        id: gate
+        run: |
+          set -euo pipefail
+          PERM=$(gh api repos/$GITHUB_REPOSITORY/collaborators/$COMMENT_USER_LOGIN/permission --jq '.permission' 2>/dev/null || echo "none")
+          if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
+
+  upload:
+    needs: check
+    if: needs.check.outputs.allowed == 'true'
+    uses: adobe/aio-reusable-workflows/.github/workflows/dependabot-coverage-upload.yml@dependabot-codecov-fix
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the dependabot-coverage-upload.yml caller workflow for testing the Dependabot codecov fix. Points at adobe/aio-reusable-workflows@dependabot-codecov-fix branch. Will be updated to @main once the fix is validated.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/ACNA-4537
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Testing ground for [[adobe/aio-reusable-workflows#dependabot-codecov-fix]](https://github.com/adobe/aio-reusable-workflows/pull/16) before rolling out to all App Builder repos. Using aio-e2e-tests as a low-risk repo to validate the end-to-end flow.


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This PR itself is the test, once merged to master, a Dependabot PR on this repo will trigger the artifact-save path in CI, and commenting /upload-coverage as an admin will validate the full upload flow.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
