### PR TITLE
chore: re-enable aio-lib-events e2e tests (#188)

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -42,9 +42,7 @@
     "requiredEnv": [ "EVENTS_ORG_ID", "EVENTS_API_KEY", "EVENTS_JWT_TOKEN", "EVENTS_CONSUMER_ORG_ID", "EVENTS_WORKSPACE_ID", "EVENTS_PROJECT_ID", "EVENTS_INTEGRATION_ID"],
     "requiredAuth": "oauth_s2s",
     "mapEnv": { "IMS_CLIENT_ID": "EVENTS_API_KEY" , "IMS_TOKEN": "EVENTS_JWT_TOKEN" },
-    "doNotLog": [ "EVENTS_JWT_TOKEN" ],
-    "disabled": true,
-    "disabledReason": "publishEvent returns 400 from eventsingress.adobe.io - upstream SDK needs CloudEvents spec update"
+    "doNotLog": [ "EVENTS_JWT_TOKEN" ]
   },
 
   "aio-lib-web" : {


### PR DESCRIPTION
## Description
Enable the e2e tests for aio-lib-events.
Failures have been fixed as part of https://github.com/adobe/aio-lib-events/pull/88
(adds the required CloudEvents `specversion` to the publishEvent payload).

## Related Issue
https://github.com/adobe/aio-lib-events/issues/80
Re-enable tracking: https://github.com/adobe/aio-e2e-tests/issues/188

## Motivation and Context

## How Has This Been Tested?

npm run e2e  (all tests are green)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.